### PR TITLE
The string value of PublishedDate for a post varies depends on the co…

### DIFF
--- a/PassleSync.Core/Extensions/ContentExtensions.cs
+++ b/PassleSync.Core/Extensions/ContentExtensions.cs
@@ -58,6 +58,10 @@ namespace PassleSync.Core.Extensions
                     {
                         AddEnumToNode(node, entity, property.Name);
                     }
+                    else if (propertyTypeInfo == typeof(DateTime))
+                    {
+                        AddDateToNode(node, entity, property.Name);
+                    }
                     else
                     {
                         AddPropertyToNode(node, entity, property.Name);
@@ -76,6 +80,12 @@ namespace PassleSync.Core.Extensions
             node.SetValue(propertyName.ToPropertyAlias(), value);
         }
 
+        public static void AddDateToNode<T>(this IContent node, T entity, string propertyName)
+        {
+            var value = entity.GetType().GetProperty(propertyName).GetValue(entity, null);
+            var formattedDate = ((DateTime)value).ToString("M/d/yyyy hh:mm:ss tt");
+            node.SetValue(propertyName.ToPropertyAlias(), formattedDate);
+        }
         public static void AddRepeatableTextstringsToNode<T>(this IContent node, T entity, string propertyName)
         {
             var items = (IEnumerable<string>)entity.GetType().GetProperty(propertyName).GetValue(entity, null);

--- a/PassleSync.Core/Models/Content/Umbraco/PasslePost.cs
+++ b/PassleSync.Core/Models/Content/Umbraco/PasslePost.cs
@@ -25,7 +25,14 @@ namespace PassleSync.Core.Models.Content.Umbraco
         /// <seealso href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings"/>
         public string GetDate(string format)
         {
-            return DateTime.Parse(PublishedDate).ToString(format);
+            try
+            {
+                return DateTime.Parse(PublishedDate).ToString(format);
+            }
+            catch (FormatException)
+            {
+                return PublishedDate;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
…ntext in which the API was called (the underlying DateTime data is the same, just the culture-specific formatting). Therefore, stipulate the saved string format to avoid parsing errors later.