### PR TITLE
Prevent the 'Discard Changes' alert showing by setting the form as pr…

### DIFF
--- a/PassleSync.Core/App_Plugins/PassleSync/backoffice/passleSync/components/organisms/syncSettings/syncSettings.controller.js
+++ b/PassleSync.Core/App_Plugins/PassleSync/backoffice/passleSync/components/organisms/syncSettings/syncSettings.controller.js
@@ -1,6 +1,6 @@
 ﻿angular.module("umbraco").controller(
     "SyncSettingsController",
-    function (passleSettingsResource, notificationsService) {
+    function (passleSettingsResource, notificationsService, $scope) {
         var vm = this;
         vm.loading = false;
 
@@ -28,6 +28,9 @@
             passleSettingsResource.save(vm.settings).then(() => {
                 vm.isSaving = false;
                 vm.buttonState = 'init';
+
+                // 'tabsForm' is in the parent 'dashboard' scope, but accessible here because `scope: true` in the 'syncSettings' directive
+                $scope.tabsForm.$setPristine();
 
                 notificationsService.success("Success", "Settings have been saved");
             }, (error) => {

--- a/PassleSync.Core/App_Plugins/PassleSync/backoffice/passleSync/components/organisms/syncSettings/syncSettings.directive.js
+++ b/PassleSync.Core/App_Plugins/PassleSync/backoffice/passleSync/components/organisms/syncSettings/syncSettings.directive.js
@@ -4,7 +4,7 @@
         return {
             restrict: 'E',
             templateUrl: '/App_Plugins/PassleSync/backoffice/passleSync/components/organisms/syncSettings/syncSettings.html',
-            scope: {}
+            scope: true
         }
     }
 );


### PR DESCRIPTION
…istine after saving.

Note: this depends on the 'packaging the plugin' branch, so as to not cause a load of merge conflicts.